### PR TITLE
Use CURL_SSLVERSION_TLSv1 instead of numeric value

### DIFF
--- a/source/modules/oe/oepaypal/core/oepaypalcurl.php
+++ b/source/modules/oe/oepaypal/core/oepaypalcurl.php
@@ -19,6 +19,11 @@
  * @copyright (C) OXID eSales AG 2003-2014
  */
 
+if (!defined('CURL_SSLVERSION_TLSv1'))
+{
+    define('CURL_SSLVERSION_TLSv1', 1);
+}
+
 /**
  * PayPal Curl class
  */
@@ -61,7 +66,7 @@ class oePayPalCurl
         'CURLOPT_VERBOSE'        => 0,
         'CURLOPT_SSL_VERIFYPEER' => false,
         'CURLOPT_SSL_VERIFYHOST' => false,
-        'CURLOPT_SSLVERSION'     => 1,
+        'CURLOPT_SSLVERSION'     => CURL_SSLVERSION_TLSv1,
         'CURLOPT_RETURNTRANSFER' => 1,
         'CURLOPT_POST'           => 1,
         'CURLOPT_HTTP_VERSION'   => CURL_HTTP_VERSION_1_1,


### PR DESCRIPTION
Understanding the meaning of numeric constants is hard. Therefore PHP provided aliases should be used.
