### PR TITLE
Fixed PayPal Express box on details page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+Thumbs.db
+.DS_STORE

--- a/source/modules/oe/oepaypal/out/src/css/paypal.css
+++ b/source/modules/oe/oepaypal/out/src/css/paypal.css
@@ -109,8 +109,8 @@
     border: none;
     float: left;
     height: auto;
-    margin: 0px;
-    padding: 0px;
+    margin: 0 0 0 117px;
+    padding: 0;
     width: 150px;
 }
 

--- a/source/modules/oe/oepaypal/views/blocks/page/details/oepaypalexpresscheckoutdetailspage.tpl
+++ b/source/modules/oe/oepaypal/views/blocks/page/details/oepaypalexpresscheckoutdetailspage.tpl
@@ -21,7 +21,6 @@
     [{oxscript add='$(".paypalHelpIcon").hover(function (){$(this).parent(".paypalExpressCheckoutMsg").children(".paypalHelpBox").toggle();});'}]
     [{oxscript add='$(".paypalHelpIcon").click(function (){return false;});'}]
     [{oxscript add='$("#paypalExpressCheckoutDetailsButton").click(function (){$("<input />").attr("type", "hidden").attr("name", "doPaypalExpressCheckoutFromDetailsPage").attr("value", "true").appendTo(".js-oxProductForm");return true;});'}]
-    [{oxscript add='$("#toBasket").prependTo($("#paypalExpressCheckoutDetailsBox"))'}]
     [{oxscript include=$oViewConf->getModuleUrl('oepaypal','out/src/js/oepaypalonclickproceedaction.js') priority=10}]
     [{oxscript add='$( "#paypalExpressCheckoutDetailsButton" ).oePayPalOnClickProceedAction( {sAction: "actionExpressCheckoutFromDetailsPage"} );'}]
 [{/if}]


### PR DESCRIPTION
- added .gitignore
- Removed Javascript to move #toBasket button on details page
- Changed left margin of .paypalExpressCheckoutDetailsBox to align it to
the #toBasket button