### PR TITLE
fixed rounding bug in Basket

### DIFF
--- a/source/modules/oe/oepaypal/models/oepaypaloxbasket.php
+++ b/source/modules/oe/oepaypal/models/oepaypaloxbasket.php
@@ -208,6 +208,10 @@ class oePayPalOxBasket extends oePayPalOxBasket_parent
         $flBasketVatValue += $this->getPayPalPayCostVat();
         $flBasketVatValue += $this->getPayPalTsProtectionCostVat();
 
+        if ($this->getDeliveryCosts() < round($this->getDeliveryCosts(), 2)) {
+            return floor($flBasketVatValue * 100) / 100;
+        }
+
         return $flBasketVatValue;
     }
 


### PR DESCRIPTION
We found a bug in one of our customers shop, where a user was unable to complete the checkout.
Error message: The totals of the cart item amounts do not match order amounts.

See for example the following order:

Total (without VAT): 236.40
VAT: 44.916
Delivery Costs (without VAT): 6.99
Delivery Costs VAT: 1.3281

Total: 289.63

The problem is, that both VATs are rounded up, so we have one cent more than we should have.

See also the following log:
```
======================= Request to PayPal [2015-11-17 10:49:53] ======================= #

SESS ID: 123sessionid456
array (
  'VERSION' => '84.0',
  'PWD' => '123SOME456CHARS',
  'USER' => 'mail_api1.shop.de',
  'SIGNATURE' => 'aVeryLongAndValidSignature.abcd',
  'CALLBACKVERSION' => '84.0',
  'LOCALECODE' => 'de_DE',
  'SOLUTIONTYPE' => 'Mark',
  'BRANDNAME' => 'DEMO Shop',
  'CARTBORDERCOLOR' => '2b8da4',
  'RETURNURL' => 'http://shop/index.php?lang=0&sid=123sessionid456&rtoken=12352789&shp=oxbaseshop&cl=oePayPalStandardDispatcher&fnc=getExpressCheckoutDetails',
  'CANCELURL' => 'http://shop/index.php?lang=0&sid=123sessionid456&rtoken=12352789&shp=oxbaseshop&cl=payment',
  'PAYMENTREQUEST_0_PAYMENTACTION' => 'Sale',
  'NOSHIPPING' => '0',
  'PAYMENTREQUEST_0_TAXAMT' => '44.92',
  'PAYMENTREQUEST_0_AMT' => '289.63',
  'PAYMENTREQUEST_0_CURRENCYCODE' => 'EUR',
  'PAYMENTREQUEST_0_ITEMAMT' => '236.40',
  'PAYMENTREQUEST_0_SHIPPINGAMT' => '8.32',
  'PAYMENTREQUEST_0_SHIPDISCAMT' => '0.00',
  'L_SHIPPINGOPTIONISDEFAULT0' => 'true',
  'L_SHIPPINGOPTIONNAME0' => 'Paketdienst',
  'L_SHIPPINGOPTIONAMOUNT0' => '8.32',
  'PAYMENTREQUEST_0_DESC' => 'Ihre Bestellung bei DEMO Shop in Höhe von 289,63 EUR',
  'PAYMENTREQUEST_0_CUSTOM' => 'Ihre Bestellung bei DEMO Shop in Höhe von 289,63 EUR',
  'ADDROVERRIDE' => '1',
  'MAXAMT' => '290.63',
  'L_PAYMENTREQUEST_0_NAME0' => 'Gesamtsumme:',
  'L_PAYMENTREQUEST_0_AMT0' => '236.40',
  'L_PAYMENTREQUEST_0_QTY0' => '1',
  'EMAIL' => 'admin@spark5.de',
  'PAYMENTREQUEST_0_SHIPTONAME' => 'Admin',
  'PAYMENTREQUEST_0_SHIPTOSTREET' => 'Teststraße 99',
  'PAYMENTREQUEST_0_SHIPTOCITY' => 'Teststadt',
  'PAYMENTREQUEST_0_SHIPTOZIP' => '79098',
  'PAYMENTREQUEST_0_SHIPTOPHONENUM' => '0800 1234567',
  'PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE' => 'DE',
  'METHOD' => 'SetExpressCheckout',
)

======================= Response from PayPal [2015-11-17 10:49:54] ======================= #

SESS ID: 123sessionid456
array (
  'TIMESTAMP' => '2015-11-17T09:49:54Z',
  'CORRELATIONID' => 'db1391c73904a',
  'ACK' => 'Failure',
  'VERSION' => '84.0',
  'BUILD' => '18308778',
  'L_ERRORCODE0' => '10413',
  'L_SHORTMESSAGE0' => 'Transaction refused because of an invalid argument. See additional error messages for details.',
  'L_LONGMESSAGE0' => 'The totals of the cart item amounts do not match order amounts.',
  'L_SEVERITYCODE0' => 'Error',
)
```