### PR TITLE
Use tls v1.2 for curl requests

### DIFF
--- a/source/modules/oe/oepaypal/core/oepaypalcurl.php
+++ b/source/modules/oe/oepaypal/core/oepaypalcurl.php
@@ -19,9 +19,9 @@
  * @copyright (C) OXID eSales AG 2003-2014
  */
 
-if (!defined('CURL_SSLVERSION_TLSv1'))
+if (!defined('CURL_SSLVERSION_TLSv1_2'))
 {
-    define('CURL_SSLVERSION_TLSv1', 1);
+    define('CURL_SSLVERSION_TLSv1_2', 6);
 }
 
 /**
@@ -66,7 +66,7 @@ class oePayPalCurl
         'CURLOPT_VERBOSE'        => 0,
         'CURLOPT_SSL_VERIFYPEER' => false,
         'CURLOPT_SSL_VERIFYHOST' => false,
-        'CURLOPT_SSLVERSION'     => CURL_SSLVERSION_TLSv1,
+        'CURLOPT_SSLVERSION'     => CURL_SSLVERSION_TLSv1_2,
         'CURLOPT_RETURNTRANSFER' => 1,
         'CURLOPT_POST'           => 1,
         'CURLOPT_HTTP_VERSION'   => CURL_HTTP_VERSION_1_1,


### PR DESCRIPTION
https://devblog.paypal.com/upcoming-security-changes-notice/#tls
Paypal is now requiring to use tls v1.2.

Currently, TLS v1 support is already dropped on sandbox ([sandbox](https://www.ssllabs.com/ssltest/analyze.html?d=api-3t.sandbox.paypal.com) / [live](https://www.ssllabs.com/ssltest/analyze.html?d=api-3t.paypal.com&s=173.0.92.21)) thus the module no longer works in sandbox mode.
