### PR TITLE
fix for verify from paypal when verify comes with null value.

### DIFF
--- a/source/modules/oe/oepaypal/models/responses/oepaypalresponsedoverifywithpaypal.php
+++ b/source/modules/oe/oepaypal/models/responses/oepaypalresponsedoverifywithpaypal.php
@@ -82,7 +82,7 @@ class oePayPalResponseDoVerifyWithPayPal extends oePayPalResponse
     {
         $aResponse = $this->getData();
 
-        return isset($aResponse[self::PAYPAL_ACK]);
+        return array_key_exists(self::PAYPAL_ACK, $aResponse);
     }
 
     /**


### PR DESCRIPTION
In the paypal logs times to times I get logs that IPN verification failed like:

```
======================= IPN VERIFICATION FAILURE BY PAYPAL [2016-03-03 18:58:30] ======================= #

SESS ID: 123123123123123123123
array (
  'Shop owner' => 'owner@owner.com',
  'PayPal ID' => '',
  'PayPal ACK' => 'VERIFIED',
  'PayPal Full Request' => 'Array
(
   ..... DATA GOES HERE ....
)
',
  'PayPal Full Response' => 'Array
(
    [VERIFIED] =>
)
',
)
```

The problem here is that paypal sometimes returns verified without any value (or maybe there is parsing error?) 

Paypal [offers](https://developer.paypal.com/docs/classic/ipn/ht_ipn/) to check response like: 

```
if (strcmp ($res, "VERIFIED") == 0) {
  // The IPN is verified, process it
} else if (strcmp ($res, "INVALID") == 0) {
  // IPN invalid, log for manual investigation
}
```

But I have other solution for paypal module just to check if array_key_exists. That would avoid conditions when null value is assigned to array because isset() [will return false](https://3v4l.org/jLXct) when array has null value.
