### PR TITLE
Update CURLOPT_SSLVERSION to CURL_SSLVERSION_TLSv1_2

### DIFF
--- a/source/modules/oe/oepaypal/core/oepaypalcurl.php
+++ b/source/modules/oe/oepaypal/core/oepaypalcurl.php
@@ -24,6 +24,12 @@ if (!defined('CURL_SSLVERSION_TLSv1'))
     define('CURL_SSLVERSION_TLSv1', 1);
 }
 
+
+if (!defined('CURL_SSLVERSION_TLSv1_2'))
+{
+    define('CURL_SSLVERSION_TLSv1_2', 6);
+}
+
 /**
  * PayPal Curl class
  */
@@ -66,7 +72,7 @@ class oePayPalCurl
         'CURLOPT_VERBOSE'        => 0,
         'CURLOPT_SSL_VERIFYPEER' => false,
         'CURLOPT_SSL_VERIFYHOST' => false,
-        'CURLOPT_SSLVERSION'     => CURL_SSLVERSION_TLSv1,
+        'CURLOPT_SSLVERSION'     => CURL_SSLVERSION_TLSv1_2,
         'CURLOPT_RETURNTRANSFER' => 1,
         'CURLOPT_POST'           => 1,
         'CURLOPT_HTTP_VERSION'   => CURL_HTTP_VERSION_1_1,


### PR DESCRIPTION
Regarding to this [official PayPal announcement](https://www.paypal-knowledge.com/infocenter/index?page=content&id=FAQ1914&expand=true&locale=en_US) the use of TLS 1.2 and HTTP/1.1 is required for Production Endpoints as of June 17, 2016. The Sandbox endpoints already enforce TLS 1.2 and HTTP/1.1 since January 2016.
