### PR TITLE
Add more files to blacklist-filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,11 @@
     "extra": {
         "oxideshop": {
             "blacklist-filter": [
-                "documentation/**/*.*"
+                "documentation/**/*.*",
+                "CHANGELOG.md",
+                "composer.json",
+                "CONTRIBUTING.md",
+                "README.md"
             ],
             "target-directory": "oe/oepaypal"
         }


### PR DESCRIPTION
The following files were added to blacklist-filter, as they are not needed in modules directory:
- CHANGELOG.md
- composer.json
- CONTRIBUTING.md
- README.md