### PR TITLE
- show extra payment costs only if they are higher than zero

### DIFF
--- a/views/blocks/page/checkout/oepaypalpaymentselector.tpl
+++ b/views/blocks/page/checkout/oepaypalpaymentselector.tpl
@@ -7,7 +7,7 @@
             <label for="payment_[{$sPaymentID}]"><b>[{$paymentmethod->oxpayments__oxdesc->value}]</b></label>
         </dt>
         <dd class="[{if $oView->getCheckedPaymentId() == $paymentmethod->oxpayments__oxid->value}]activePayment[{/if}]">
-            [{if $paymentmethod->getPrice()}]
+            [{if $paymentmethod->getPrice() && $paymentmethod->oxpayments__oxaddsum->rawValue > 0}]
                 [{if $oxcmp_basket->getPayCostNet()}]
                     [{$paymentmethod->getFNettoPrice()}] [{$currency->sign}] [{oxmultilang ident="OEPAYPAL_PLUS_VAT"}] [{$paymentmethod->getFPriceVat()}]
                 [{else}]


### PR DESCRIPTION
### As a customer I only want to be informed about extra payment costs, if they are higher than zero.

**Status Quo:** 
The current behavior shows the customer all values including zero. So if my extra payment costs are set to 0 and the currency is € the template will show 0.00€ extra costs to the customer. This differs from the OXID default behavior which only shows extra costs on a payment, if they are higher than zero.

**Bugfix**
The Bugfix extends the condition to check if the current extra payment cost raw value is higher than zero. Only in this case the condition will be true and the extra costs will be shown to the customer.

**Additional Information**
I want to sign the [contribution agreements](https://gist.github.com/OXID-Admin/6df6ed126d074a54507d) which are referred in the guidelines, but the links down the document are broken. 