### PR TITLE
handleRequest() should not return boolean

### DIFF
--- a/Controller/IPNHandler.php
+++ b/Controller/IPNHandler.php
@@ -133,7 +133,7 @@ class IPNHandler extends \OxidEsales\PayPalModule\Controller\FrontendController
      *  - Call to check if request is valid (from PayPal and to correct shop).
      *  - Initiate payment status changes according to IPN information.
      *
-     * @return bool
+     * @return null
      */
     public function handleRequest()
     {
@@ -159,7 +159,8 @@ class IPNHandler extends \OxidEsales\PayPalModule\Controller\FrontendController
             $requestHandled = $processor->process();
         }
 
-        return $requestHandled;
+        // this can't be boolean -> see BaseController->executeFunction() -> if value is true, an exception is thrown
+        //return $requestHandled;
     }
 
     /**


### PR DESCRIPTION
Paypal contacts the shop with this request: index.php?cl=oepaypalipnhandler&fnc=handleRequest&shp=1
And if handleRequest() returns "true", BaseController->executeFunction('handleRequest') tries to execute BaseController->_executeNewAction(true) which leads to an exception.