### PR TITLE
Fixed var

### DIFF
--- a/Controller/IPNHandler.php
+++ b/Controller/IPNHandler.php
@@ -35,7 +35,7 @@ class IPNHandler extends \OxidEsales\PayPalModule\Controller\FrontendController
      *
      * @var string
      */
-    protected $thisTemplate = 'ipnhandler.tpl';
+    protected $_sThisTemplate = 'ipnhandler.tpl';
 
     /**
      * PayPal request handler.


### PR DESCRIPTION
protected $thisTemplate is wrong. Should be protected $_sThisTemplate.

This caused IPN-Handler to spam warnings in apaches error.log:
[Thu Feb 07 15:10:47.010789 2019] [php7:warn] [pid 4446] [client XXX] PHP Warning:  Smarty error: unable to read resource: &quot;&quot; in XXX/vendor/smarty/smarty/libs/Smarty.class.php on line 1100