### PR TITLE
add missing colgroup in admin panels order_list table ...

### DIFF
--- a/views/blocks/oepaypalorder_list_colgroup_actions.tpl
+++ b/views/blocks/oepaypalorder_list_colgroup_actions.tpl
@@ -1,2 +1,3 @@
 <col width="10%">
+<col width="10%">
 [{$smarty.block.parent}]


### PR DESCRIPTION
... because it breaks the last name column layout

![Screenshot 2021-06-08 143855](https://user-images.githubusercontent.com/9882400/121186351-4a612800-c867-11eb-959e-03bf6bfbf576.jpg)
