### PR TITLE
add missing colgroup in admin panels order_list table...

### DIFF
--- a/views/blocks/oepaypalorder_list_colgroup_actions.tpl
+++ b/views/blocks/oepaypalorder_list_colgroup_actions.tpl
@@ -1,2 +1,3 @@
 <col width="10%">
+<col width="10%">
 [{$smarty.block.parent}]


### PR DESCRIPTION
... because it breaks the last name column layout

![Screenshot 2021-06-08 143855](https://user-images.githubusercontent.com/4622554/121186921-d3785f00-c867-11eb-8fb0-cf480e380256.jpg)
