### PR TITLE
Fix order list filtering and sorting compatibility with other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.3.2] - Unreleased
+
+### Fixed
+- OrderList::_buildSelectString is giving congruent result after replacing "from order" part [PR-54](https://github.com/OXID-eSales/paypal/pull/54)
+
 ## [6.3.1] - 2021-07-19
 
 ### Changed
@@ -254,6 +259,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Additional PayPal express checkout button in user checkout step in case no user is logged in.
 
+[6.3.2]: https://github.com/OXID-eSales/paypal/compare/v6.3.1...b-6.x
 [6.3.1]: https://github.com/OXID-eSales/paypal/compare/v6.3.0...v6.3.1
 [6.3.0]: https://github.com/OXID-eSales/paypal/compare/v6.2.3...v6.3.0
 [6.2.3]: https://github.com/OXID-eSales/paypal/compare/v6.2.2...v6.2.3

--- a/Controller/Admin/OrderList.php
+++ b/Controller/Admin/OrderList.php
@@ -69,7 +69,7 @@ class OrderList extends OrderList_parent
         $viewNameGenerator = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\TableViewNameGenerator::class);
         $viewName = $viewNameGenerator->getViewName("oxpayments");
 
-        $queryPart = ", `oepaypal_order`.`oepaypal_paymentstatus`, `payments`.`oxdesc` as `paymentname` from `oxorder`
+        $queryPart = ", `oepaypal_order`.`oepaypal_paymentstatus`, `payments`.`oxdesc` as `paymentname` from oxorder
         LEFT JOIN `oepaypal_order` ON `oepaypal_order`.`oepaypal_orderid` = `oxorder`.`oxid`
         LEFT JOIN `" . $viewName . "` AS `payments` on `payments`.oxid=oxorder.oxpaymenttype ";
 


### PR DESCRIPTION
Due to the fact that there is no query builder API present, the sql string for admin select lists is manipulated directly.
A lot of modules use `str_replace` to find the part `from oxorder` in order to add further columns or joins to the query.

However, this paypal module breaks compatiblity between modules by replacing `from oxorder` with the backticks-quoted identifier variant.
This can lead to exceptions being thrown when users click on a sorting link in the list's header (because for example some some joins could not be applied with `str_replace`).

This PR replaces the quoted oxorder identifier with its unquoted variant. This variant is also used by in the sql string returned from the parent class (`OrderList::_buildSelectString()`)).